### PR TITLE
ci: Run gdc tests with a more up-to-date gdc compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: d
+sudo: required
+dist: xenial
+
+services:
+  - docker
 
 d:
   - dmd
   - gdc
   - ldc
 
+before_script:
+  - if [[ "$DC" == "gdc" ]]; then docker build -t debtesting -f ci/Dockerfile .; fi
+
 script:
-  - dub test -b unittest-cov
+  - if [[ "$DC" == "gdc" ]]; then
+    docker run -t -e DC=$DC -v `pwd`:/build debtesting
+     ./ci/build-and-test.sh; fi
+  - if [[ "$DC" != "gdc" ]]; then ./ci/build-and-test.sh; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-sudo: false

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,16 @@
+#
+# Docker file for json-patch CI tests
+#
+FROM debian:unstable
+
+# NOTE: Switch back to debian:testing when GDC 8.1 is default in testing as well
+
+# prepare
+RUN apt-get update -qq
+
+# install build essentials
+RUN apt-get install -yq gcc gdc ldc meson dub
+
+# finish
+RUN mkdir /build
+WORKDIR /build

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# This script is supposed to run inside the Debian Testing Docker container
+# on the CI system.
+#
+set -e
+export LANG=C.UTF-8
+
+echo "D compiler: $DC"
+set -v
+$DC --version
+
+#
+# Build & Test
+#
+dub test -b unittest-cov


### PR DESCRIPTION
Hi!
For my projects, I usually build things in a Docker container or chroot on Travis, to get more up-to-date software components than Travis usually has, which especially includes an updated GDC.

You can use that as a workaround for the Travis D profile only having an ancient GDC version at the moment. Having this involves a bit of boilerplate code though, as you can see in the patch.

This is pretty much a response to / workaround for https://forum.dlang.org/thread/njdbrvlwjbmzeplgildj@forum.dlang.org and might also help other facing this issue right now, even if you don't want to go down this route (and alternative would just be to allow failures for gc builds for now and wait for the Travis profile to update (which hasn't happened for more than half a year though).

Cheers,
    Matthias